### PR TITLE
Rename package to code in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "FrontEndConvivo",
+  "name": "code",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
This pull request renames the package from `FrontEndConvivo` to `code` in `package-lock.json`.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7f6cc8603b7c48f79d19c700761788f9/pixel-field)

👀 [Preview Link](https://7f6cc8603b7c48f79d19c700761788f9-pixel-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7f6cc8603b7c48f79d19c700761788f9</projectId>-->
<!--<branchName>pixel-field</branchName>-->